### PR TITLE
Fix lobby loading race and param reading

### DIFF
--- a/app/lobby/[code]/page.tsx
+++ b/app/lobby/[code]/page.tsx
@@ -1,13 +1,11 @@
 "use client";
 
-import { useSearchParams } from "next/navigation";
+import { useParams } from "next/navigation";
 import LobbyClient from "@/components/LobbyClient";
 
 export default function LobbyWrapper() {
-  const searchParams = useSearchParams();
-  const code = typeof window !== "undefined"
-    ? window.location.pathname.split("/").pop() ?? ""
-    : "";
+  const params = useParams<{ code: string }>();
+  const code = params.code ?? "";
 
   return <LobbyClient lobbyCode={code} />;
 }


### PR DESCRIPTION
## Summary
- ensure lobby client registers socket listeners before emitting join event
- use `useParams` hook in lobby wrapper for reliable code access

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ad90eef00832eb4e351ee8c929c5d