### PR TITLE
Add basic game phase

### DIFF
--- a/app/game/[code]/page.tsx
+++ b/app/game/[code]/page.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import { getSocket } from "@/lib/socket";
+import { GameState } from "@/lib/gameLogic";
+import MoneyDisplay from "@/components/MoneyDisplay";
+import GameControls from "@/components/GameControls";
+import TransactionHistory from "@/components/TransactionHistory";
+
+export default function GamePage() {
+  const params = useParams<{ code: string }>();
+  const code = params.code ?? "";
+  const [game, setGame] = useState<GameState | null>(null);
+  const [myName, setMyName] = useState("");
+  const [myId, setMyId] = useState("");
+
+  useEffect(() => {
+    const stored = localStorage.getItem("playerName");
+    if (stored) setMyName(stored);
+    const socket = getSocket();
+
+    const handleState = (state: GameState) => setGame(state);
+    socket.on("game-state", handleState);
+    socket.on("game-updated", handleState);
+    setMyId(socket.id);
+    socket.emit("request-game-state", code);
+
+    return () => {
+      socket.off("game-state", handleState);
+      socket.off("game-updated", handleState);
+    };
+  }, [code]);
+
+  if (!game) {
+    return <div className="p-4">Yükleniyor...</div>;
+  }
+
+  const isOwner = game.owner === myName;
+  const isMyTurn = game.players[game.currentTurn]?.id === myId;
+
+  return (
+    <div className="p-4 space-y-4">
+      <MoneyDisplay players={game.players} currentTurn={game.currentTurn} />
+      {isMyTurn && (
+        <GameControls lobbyCode={code} players={game.players} meId={myId} />
+      )}
+      <TransactionHistory
+        transactions={game.transactions}
+        players={game.players}
+        isOwner={isOwner}
+        lobbyCode={code}
+      />
+    </div>
+  );
+}
+

--- a/components/GameControls.tsx
+++ b/components/GameControls.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useState } from "react";
+import { GamePlayer } from "@/lib/gameLogic";
+import { getSocket } from "@/lib/socket";
+
+type Props = {
+  lobbyCode: string;
+  players: GamePlayer[];
+  meId: string;
+};
+
+export default function GameControls({ lobbyCode, players, meId }: Props) {
+  const socket = getSocket();
+  const [amount, setAmount] = useState(0);
+  const [target, setTarget] = useState<string>("");
+
+  const send = (event: string, payload: any) => {
+    socket.emit(event, { code: lobbyCode, ...payload });
+    setAmount(0);
+  };
+
+  const handleAdd = () => send("add-money", { playerId: meId, amount });
+  const handleSubtract = () => send("subtract-money", { playerId: meId, amount });
+  const handleTransfer = () => {
+    if (!target) return;
+    send("transfer-money", { fromId: meId, toId: target, amount });
+  };
+
+  const endTurn = () => socket.emit("end-turn", lobbyCode);
+
+  return (
+    <div className="space-y-2">
+      <input
+        type="number"
+        className="border p-1 rounded w-full"
+        value={amount}
+        onChange={(e) => setAmount(Number(e.target.value))}
+      />
+      <div className="flex gap-2">
+        <button onClick={handleAdd} className="bg-green-500 text-white px-3 py-1 rounded">Ekle</button>
+        <button onClick={handleSubtract} className="bg-yellow-500 text-white px-3 py-1 rounded">Çıkar</button>
+      </div>
+      <div className="flex items-center gap-2">
+        <select className="border p-1 rounded" value={target} onChange={(e) => setTarget(e.target.value)}>
+          <option value="">Seç Oyuncu</option>
+          {players.filter(p => p.id !== meId).map(p => (
+            <option key={p.id} value={p.id}>{p.name}</option>
+          ))}
+        </select>
+        <button onClick={handleTransfer} className="bg-blue-500 text-white px-3 py-1 rounded">Transfer</button>
+      </div>
+      <button onClick={endTurn} className="bg-gray-700 text-white px-3 py-1 rounded w-full">Sıra Bitir</button>
+    </div>
+  );
+}
+

--- a/components/MoneyDisplay.tsx
+++ b/components/MoneyDisplay.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { GamePlayer } from "@/lib/gameLogic";
+
+type Props = {
+  players: GamePlayer[];
+  currentTurn: number;
+};
+
+export default function MoneyDisplay({ players, currentTurn }: Props) {
+  return (
+    <table className="min-w-full text-left border-collapse">
+      <thead>
+        <tr>
+          <th className="px-4 py-2">Oyuncu</th>
+          <th className="px-4 py-2">Bakiye</th>
+        </tr>
+      </thead>
+      <tbody>
+        {players.map((p, idx) => (
+          <tr
+            key={p.id}
+            className={idx === currentTurn ? "bg-green-100" : ""}
+          >
+            <td className="px-4 py-2 font-medium">{p.name}</td>
+            <td className="px-4 py-2">${p.balance}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+

--- a/components/TransactionHistory.tsx
+++ b/components/TransactionHistory.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { Transaction, GamePlayer } from "@/lib/gameLogic";
+
+type Props = {
+  transactions: Transaction[];
+  players: GamePlayer[];
+  isOwner: boolean;
+  lobbyCode: string;
+};
+
+export default function TransactionHistory({ transactions, players, isOwner, lobbyCode }: Props) {
+  const socket = require("@/lib/socket").getSocket();
+
+  const nameOf = (id?: string) => players.find(p => p.id === id)?.name || "?";
+
+  const handleDelete = (id: string) => {
+    socket.emit("delete-transaction", { code: lobbyCode, id });
+  };
+
+  if (transactions.length === 0) {
+    return <p className="text-sm text-gray-500">Henüz işlem yok.</p>;
+  }
+
+  return (
+    <ul className="space-y-1">
+      {transactions.map((t) => {
+        let text = "";
+        if (t.type === "add") {
+          text = `${nameOf(t.to)} bankadan ${t.amount}$ aldı`;
+        } else if (t.type === "subtract") {
+          text = `${nameOf(t.from)} bankaya ${t.amount}$ ödedi`;
+        } else {
+          text = `${nameOf(t.from)} -> ${nameOf(t.to)} : ${t.amount}$`;
+        }
+        return (
+          <li key={t.id} className="flex justify-between items-center bg-white border px-2 py-1 rounded">
+            <span>{text}</span>
+            {isOwner && (
+              <button className="text-red-500" onClick={() => handleDelete(t.id)}>Sil</button>
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+

--- a/lib/gameLogic.ts
+++ b/lib/gameLogic.ts
@@ -1,0 +1,20 @@
+export type GamePlayer = {
+  id: string;
+  name: string;
+  balance: number;
+};
+
+export type Transaction = {
+  id: string;
+  type: "add" | "subtract" | "transfer";
+  from?: string;
+  to?: string;
+  amount: number;
+};
+
+export type GameState = {
+  players: GamePlayer[];
+  currentTurn: number;
+  owner: string;
+  transactions: Transaction[];
+};


### PR DESCRIPTION
## Summary
- create data types for game logic
- implement MoneyDisplay, GameControls and TransactionHistory components
- add game page that uses new components and socket events
- extend socket-server with in-memory game state management

## Testing
- `npm run build` *(fails: next not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b0c3a72c0832ea0146abb80868eb7