### PR TITLE
Add quick amount buttons and darken text

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5,7 +5,8 @@
 
 :root {
   --background: #ffffff;
-  --foreground: #171717;
+  /* Make default text darker for better readability */
+  --foreground: #000000;
 }
 
 @theme inline {

--- a/components/GameControls.tsx
+++ b/components/GameControls.tsx
@@ -37,6 +37,19 @@ export default function GameControls({ lobbyCode, players, meId }: Props) {
         value={amount}
         onChange={(e) => setAmount(Number(e.target.value))}
       />
+      {/* Quick amount buttons */}
+      <div className="flex gap-2">
+        {[10, 50, 100].map((val) => (
+          <button
+            key={val}
+            type="button"
+            onClick={() => setAmount((a) => a + val)}
+            className="bg-gray-200 text-black px-2 py-1 rounded"
+          >
+            +{val}
+          </button>
+        ))}
+      </div>
       <div className="flex gap-2">
         <button onClick={handleAdd} className="bg-green-500 text-white px-3 py-1 rounded">Ekle</button>
         <button onClick={handleSubtract} className="bg-yellow-500 text-white px-3 py-1 rounded">Çıkar</button>


### PR DESCRIPTION
## Summary
- darken default text color for better readability
- add quick amount buttons in `GameControls`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685b1436e8d8832ea16c297ce2e7a49a