### PR TITLE
Add player order management in lobby

### DIFF
--- a/components/LobbyClient.tsx
+++ b/components/LobbyClient.tsx
@@ -4,6 +4,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { getSocket } from "@/lib/socket"; // Doğru yolu kontrol edin
+import PlayerList from "./PlayerList";
 
 // Oyuncu tipi tanımı: Şimdi id içeriyor
 type Player = {
@@ -165,27 +166,12 @@ export default function LobbyClient({ lobbyCode }: { lobbyCode: string }) {
           </span>
         </h2>
         <h3 className="text-2xl font-bold mb-4 text-indigo-700 drop-shadow">Oyuncular:</h3>
-        <ul className="mb-6 space-y-2">
-          {/* Oyuncu listesini render et */}
-          {lobby.players.map((player) => {
-            console.log(`Oyuncu render ediliyor: ID='${player.id}', İsim='${player.name}'`);
-            return (
-              <li
-                key={player.id}
-                className="py-2 px-4 bg-gradient-to-r from-blue-50 to-indigo-100 rounded-lg flex items-center justify-between shadow-md border-2 border-blue-100"
-              >
-                <span className="font-bold text-indigo-800 text-lg drop-shadow">
-                  {player.name && player.name.trim() !== '' ? player.name : "İsimsiz Oyuncu"}
-                </span>
-                {player.name === lobby.owner && (
-                  <span className="text-base text-purple-700 font-extrabold bg-purple-100 px-3 py-1 rounded-full shadow">
-                    Kurucu
-                  </span>
-                )}
-              </li>
-            );
-          })}
-        </ul>
+        <PlayerList
+          players={lobby.players}
+          isOwner={isOwner}
+          lobbyCode={lobbyCode}
+          owner={lobby.owner}
+        />
         {isOwner && (
           <div className="flex flex-col gap-5 p-4 bg-blue-50 rounded-lg border-2 border-blue-300 shadow">
             <label htmlFor="balance-input" className="text-lg font-bold text-indigo-700">

--- a/components/PlayerList.tsx
+++ b/components/PlayerList.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getSocket } from "@/lib/socket";
+
+type Player = { id: string; name: string };
+
+type Props = {
+  players: Player[];
+  isOwner: boolean;
+  lobbyCode: string;
+  owner: string;
+};
+
+export default function PlayerList({ players, isOwner, lobbyCode, owner }: Props) {
+  const socket = getSocket();
+  const [order, setOrder] = useState<Player[]>(players);
+
+  useEffect(() => {
+    setOrder(players);
+  }, [players]);
+
+  const move = (index: number, dir: number) => {
+    const newOrder = [...order];
+    const target = index + dir;
+    if (target < 0 || target >= newOrder.length) return;
+    [newOrder[index], newOrder[target]] = [newOrder[target], newOrder[index]];
+    setOrder(newOrder);
+    socket.emit("set-player-order", {
+      code: lobbyCode,
+      order: newOrder.map((p) => p.id),
+    });
+  };
+
+  return (
+    <ul className="mb-6 space-y-2">
+      {order.map((player, i) => (
+        <li
+          key={player.id}
+          className="py-2 px-4 bg-gradient-to-r from-blue-50 to-indigo-100 rounded-lg flex items-center justify-between shadow-md border-2 border-blue-100"
+        >
+          <span className="font-bold text-indigo-800 text-lg drop-shadow">
+            {player.name && player.name.trim() !== "" ? player.name : "İsimsiz Oyuncu"}
+          </span>
+          <div className="flex items-center gap-1">
+            {player.name === owner && (
+              <span className="text-base text-purple-700 font-extrabold bg-purple-100 px-3 py-1 rounded-full shadow mr-2">
+                Kurucu
+              </span>
+            )}
+            {isOwner && (
+              <>
+                <button
+                  className="px-2 text-sm border rounded disabled:opacity-50"
+                  onClick={() => move(i, -1)}
+                  disabled={i === 0}
+                >
+                  ▲
+                </button>
+                <button
+                  className="px-2 text-sm border rounded disabled:opacity-50"
+                  onClick={() => move(i, 1)}
+                  disabled={i === order.length - 1}
+                >
+                  ▼
+                </button>
+              </>
+            )}
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/socket-server.ts
+++ b/socket-server.ts
@@ -211,6 +211,25 @@ io.on("connection", (socket) => {
     io.to(code).emit("game-updated", game);
   });
 
+  socket.on(
+    "set-player-order",
+    ({ code, order }: { code: string; order: string[] }) => {
+      const lobby = lobbies[code];
+      if (!lobby) return;
+      if (order.length !== lobby.players.length) return;
+      const idSet = new Set(lobby.players.map((p) => p.id));
+      if (!order.every((id) => idSet.has(id))) return;
+      lobby.players.sort(
+        (a, b) => order.indexOf(a.id) - order.indexOf(b.id)
+      );
+      io.to(code).emit("lobby-updated", {
+        code,
+        players: lobby.players,
+        owner: lobby.owner,
+      });
+    }
+  );
+
   // Bir soket bağlantısı kesildiğinde
   socket.on("disconnect", () => {
     console.log(`❌ Soket bağlantısı kesildi: ${socket.id}`);


### PR DESCRIPTION
## Summary
- allow lobby host to reorder players before starting the game
- send new order to server with a new `set-player-order` event
- update server to handle `set-player-order`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b162e3934832ea97e368e15574488