### PR TITLE
Improve interface colors

### DIFF
--- a/app/game/[code]/page.tsx
+++ b/app/game/[code]/page.tsx
@@ -50,7 +50,7 @@ export default function GamePage() {
   const isMyTurn = game.players[game.currentTurn]?.id === myId;
 
   return (
-    <div className="min-h-screen w-full bg-gradient-to-br from-slate-900 to-gray-900 text-white p-4 sm:p-6 lg:p-8">
+    <div className="min-h-screen w-full bg-gradient-to-br from-gray-900 via-purple-900 to-black text-white p-4 sm:p-6 lg:p-8">
       <div className="max-w-7xl mx-auto">
         <header className="mb-8 text-center">
             <h1 className="text-4xl font-bold tracking-tight">Oyun Kodu: <span className="text-cyan-400">{code}</span></h1>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,9 +3,9 @@ import JoinOrCreateLobbyForm from "@/components/JoinOrCreateLobbyForm";
 
 export default function Home() {
   return (
-    <main className="min-h-screen flex items-center justify-center bg-gradient-to-br from-yellow-200 via-pink-200 to-blue-300 animate-gradient-x">
+    <main className="min-h-screen flex items-center justify-center bg-gradient-to-br from-pink-300 via-amber-300 to-sky-400 animate-gradient-x">
       <div className="bg-white p-8 rounded-2xl shadow-md w-full max-w-md">
-        <h1 className="text-4xl font-extrabold text-center mb-6 text-transparent bg-clip-text bg-gradient-to-r from-pink-500 via-yellow-400 to-blue-500 drop-shadow-lg tracking-wide animate-pulse-slow">
+        <h1 className="text-4xl font-extrabold text-center mb-6 text-transparent bg-clip-text bg-gradient-to-r from-fuchsia-600 via-amber-500 to-cyan-500 drop-shadow-lg tracking-wide animate-pulse-slow">
           Monopoly Digital Bank
         </h1>
         <JoinOrCreateLobbyForm />

--- a/components/LobbyClient.tsx
+++ b/components/LobbyClient.tsx
@@ -116,7 +116,7 @@ export default function LobbyClient({ lobbyCode }: { lobbyCode: string }) {
   // Loading state while lobby data is being fetched
   if (!lobby) {
     return (
-      <div className="flex flex-col items-center justify-center min-h-screen bg-gradient-to-br from-blue-200 to-indigo-300 p-4">
+      <div className="flex flex-col items-center justify-center min-h-screen bg-gradient-to-br from-cyan-300 via-sky-400 to-indigo-500 p-4">
         <div className="p-6 text-center text-gray-800 bg-white shadow-2xl rounded-2xl animate-pulse border-2 border-blue-200">
           <div className="mb-2 text-2xl font-extrabold tracking-wide">
             <span className="font-extrabold text-indigo-700 drop-shadow">Lobby Code:</span>{" "}
@@ -139,7 +139,7 @@ export default function LobbyClient({ lobbyCode }: { lobbyCode: string }) {
 
   // Main lobby screen (player list and start settings)
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen bg-gradient-to-br from-blue-200 to-indigo-300 p-4">
+    <div className="flex flex-col items-center justify-center min-h-screen bg-gradient-to-br from-cyan-300 via-sky-400 to-indigo-500 p-4">
       <div className="p-8 max-w-lg w-full bg-white shadow-2xl rounded-2xl mt-10 border-2 border-blue-200">
         <h2 className="text-4xl font-extrabold mb-6 text-center text-indigo-800 drop-shadow">
           Lobby Code:{" "}

--- a/components/PlayerList.tsx
+++ b/components/PlayerList.tsx
@@ -37,7 +37,7 @@ export default function PlayerList({ players, isOwner, lobbyCode, owner }: Props
       {order.map((player, i) => (
         <li
           key={player.id}
-          className="py-2 px-4 bg-gradient-to-r from-blue-50 to-indigo-100 rounded-lg flex items-center justify-between shadow-md border-2 border-blue-100"
+          className="py-2 px-4 bg-gradient-to-r from-cyan-200 to-blue-400 rounded-lg flex items-center justify-between shadow-md border-2 border-blue-300"
         >
           <span className="font-bold text-indigo-800 text-lg drop-shadow">
             {player.name && player.name.trim() !== "" ? player.name : "İsimsiz Oyuncu"}


### PR DESCRIPTION
## Summary
- update landing page gradient colors
- update lobby gradients with brighter scheme
- make player list entries use brighter color
- adjust game page background gradient

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ba99aba38832eae9068f0943b9742