### PR TITLE
Implement kick feature for lobby owner

### DIFF
--- a/components/LobbyClient.tsx
+++ b/components/LobbyClient.tsx
@@ -77,9 +77,15 @@ export default function LobbyClient({ lobbyCode }: { lobbyCode: string }) {
       router.push("/");
     };
 
+    const handleKicked = () => {
+      alert("Lobiden atıldınız.");
+      router.push("/");
+    };
+
     socket.on("lobby-updated", handleLobbyUpdate);
     socket.on("game-started", handleGameStarted);
     socket.on("join-error", handleJoinError);
+    socket.on("kicked", handleKicked);
 
     const handleConnect = () => {
       socket.emit("join-lobby", { name: playerName, code: lobbyCode });
@@ -101,6 +107,7 @@ export default function LobbyClient({ lobbyCode }: { lobbyCode: string }) {
       socket.off("lobby-updated", handleLobbyUpdate);
       socket.off("game-started", handleGameStarted);
       socket.off("join-error", handleJoinError);
+      socket.off("kicked", handleKicked);
     };
   }, [playerName, lobbyCode, router]); // playerName ve router bağımlılık olarak eklendi
 

--- a/components/PlayerList.tsx
+++ b/components/PlayerList.tsx
@@ -32,6 +32,10 @@ export default function PlayerList({ players, isOwner, lobbyCode, owner }: Props
     });
   };
 
+  const kick = (playerId: string) => {
+    socket.emit("kick-player", { code: lobbyCode, playerId });
+  };
+
   return (
     <ul className="mb-6 space-y-2">
       {order.map((player, i) => (
@@ -64,6 +68,15 @@ export default function PlayerList({ players, isOwner, lobbyCode, owner }: Props
                 >
                   ▼
                 </button>
+                {player.name !== owner && (
+                  <button
+                    className="ml-1 px-2 text-sm border rounded font-bold text-red-700 bg-red-200 hover:bg-red-300 transition-colors"
+                    onClick={() => kick(player.id)}
+                    title="Oyuncuyu at"
+                  >
+                    ❌
+                  </button>
+                )}
               </>
             )}
           </div>


### PR DESCRIPTION
## Summary
- add `kick-player` event on socket server
- allow lobby owner to remove users from the lobby via PlayerList
- handle `kicked` event on the client to redirect removed players

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bcc2d156c832ea2c8377b46359303